### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "nodejs"
+#run = "yarn build:production && npx serve dist"
+run ="yarn install && npx vue-cli-service serve --fix"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Latitude
-Created with CodeSandbox
+
+[![Run on Repl.it](https://repl.it/badge/github/opencoca/Latitude)](https://repl.it/github/opencoca/Latitude)
+


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).